### PR TITLE
Don't fail on drop index IDX_US_SESS_ID_ON_CL_SESS (fixes #33780)

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.0.0.xml
@@ -93,6 +93,12 @@
     </changeSet>
 
     <changeSet author="keycloak" id="26.0.0-32583-drop-redundant-index-on-client-session">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <and>
+                <dbms type="oracle"/>
+                <indexExists indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
+            </and>
+        </preConditions>
         <dropIndex indexName="IDX_US_SESS_ID_ON_CL_SESS" tableName="OFFLINE_CLIENT_SESSION" />
     </changeSet>
     


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
This PR tries to fix the issue described in #33780 by using the same approach as in [jpa-changelog-24.0.2.xml](https://github.com/keycloak/keycloak/blob/main/model/jpa/src/main/resources/META-INF/jpa-changelog-24.0.2.xml#L25).

__________________________________
_Note:_ I wanted to test it by building Keycloak as described in [docs/building.md](https://github.com/keycloak/keycloak/blob/main/docs/building.md), but it failed with the following error (despite having JDK 21):
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project keycloak-common: Fatal error compiling: Fehler: Releaseversion 8 nicht unterstützt -> [Help 1]
```

So my changes are untested so far and I hope someone else can check it.